### PR TITLE
fix removal of dependencies on `uninstall`

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function run (options, callback) {
       callback(null)
       events.emit('postuninstall', version)
     }
-    var child = npmSpawn.uninstall(name, options.child_process, uninstallDone)
+    var child = npmSpawn.uninstall([name, '--no-save'], options.child_process, uninstallDone)
     events.emit('preuninstall', version, child)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,15 @@ var path = require('path')
 var run = require('../')
 
 test(function (t) {
-  t.plan(7)
+  t.plan(8)
   var logPath = path.resolve(__dirname, 'log')
   var config = {
     name: 'has-require',
     versions: ['1.0.0', '1.1.0'],
-    command: 'sh test/log.sh'
+    command: 'sh log.sh',
+    child_process: {
+      cwd: __dirname
+    }
   }
   run(config, done)
   function done (err, results) {
@@ -27,6 +30,7 @@ test(function (t) {
     t.deepEqual(items.map(function (item) {
       return item.version
     }), config.versions)
+    t.ok(require('./package.json').peerDependencies, 'peer dependencies should be preserved')
     fs.unlinkSync(logPath)
   }
 })

--- a/test/log.sh
+++ b/test/log.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 get_version='JSON.stringify({version: require("has-require/package.json").version})'
-node -p "$get_version" >> test/log
-printf '\n' >> test/log
+node -p "$get_version" >> ./log
+printf '\n' >> ./log

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,5 @@
+{
+  "peerDependencies": {
+    "has-require": "1"
+  }
+}


### PR DESCRIPTION
In `npm@8` and possibly early versions, `uninstall` modifies the `package.json`. Passing the `--no-save` option to it prevents this. Adds a test against this issue.